### PR TITLE
Delete check-module whitespacing

### DIFF
--- a/tslint-config-5minds/package.json
+++ b/tslint-config-5minds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-config-5minds",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "tslint-rules we use at 5minds",
   "main": "index.js",
   "scripts": {

--- a/tslint-config-5minds/tslint.json
+++ b/tslint-config-5minds/tslint.json
@@ -147,7 +147,6 @@
       "check-branch",
       "check-decl",
       "check-operator",
-      "check-module",
       "check-separator",
       "check-type",
       "check-typecast",


### PR DESCRIPTION
#5 
check-module enforces the following whitespacing:
`import { FrameworkConfiguration } from 'aurelia-framework';`
We want our imports to look like this instead:
`import {FrameworkConfiguration} from 'aurelia-framework';`