### PR TITLE
✨ valid-jsdoc for typescript-projects

### DIFF
--- a/tslint-eslint-config-5minds/tslint.json
+++ b/tslint-eslint-config-5minds/tslint.json
@@ -3,5 +3,8 @@
     "tslint-eslint-rules",
     "eslint-config-5minds",
     "tslint-config-5minds"
-  ]
+  ],
+  "rules": {
+    "valid-jsdoc": false,
+  }
 }


### PR DESCRIPTION
This makes tslint not scream at us when we dont add types to our typedoc-documentation