### PR TITLE
⬆ Dependencies updated

### DIFF
--- a/eslint-config-5minds-typescript/fast.js
+++ b/eslint-config-5minds-typescript/fast.js
@@ -8,5 +8,8 @@ module.exports = {
     '@typescript-eslint/prefer-includes': 'off',
     '@typescript-eslint/prefer-string-starts-ends-with': 'off',
     '@typescript-eslint/unbound-method': 'off',
+    '@typescript-eslint/strict-boolean-expressions': 'off',
+    '@typescript-eslint/no-floating-promises': 'off',
+    '@typescript-eslint/prefer-regexp-exec': 'off'
   }
 };

--- a/eslint-config-5minds-typescript/index.js
+++ b/eslint-config-5minds-typescript/index.js
@@ -16,7 +16,7 @@ module.exports  = {
     }],
 
     '@typescript-eslint/adjacent-overload-signatures': ['error'],
-    '@typescript-eslint/array-type': ['error', 'generic'],
+    '@typescript-eslint/array-type': ['error', {'default': 'generic'}],
     '@typescript-eslint/ban-types': ['error', {
       "types": {
         'Object': "Use object instead.",
@@ -75,21 +75,33 @@ module.exports  = {
         "instance-method"
       ]
     }],
-    '@typescript-eslint/no-angle-bracket-type-assertion': 'off',
     '@typescript-eslint/no-array-constructor': ['error'],
     '@typescript-eslint/no-empty-interface': ['error'],
     '@typescript-eslint/no-explicit-any': ['error'],
     '@typescript-eslint/no-extraneous-class': ['error'],
+    '@typescript-eslint/no-floating-promises': ['error'],
     '@typescript-eslint/no-for-in-array': ['error'],
     '@typescript-eslint/no-inferrable-types': ['error'],
+    "no-magic-numbers": 'off',
+    '@typescript-eslint/no-magic-numbers': ['error', {
+      'ignoreReadonlyClassProperties': true,
+      'ignoreEnums': true,
+      'ignore': [
+        -1, 0, 1, // for sorting and simple array accessing
+        24, 60, 500, 1000, // for working with timers
+      ],
+    }],
     '@typescript-eslint/no-misused-new': ['error'],
     '@typescript-eslint/no-namespace': ['error'],
     '@typescript-eslint/no-non-null-assertion': ['error'],
-    '@typescript-eslint/no-object-literal-type-assertion': ['error', {'allowAsParameter': true}],
+    '@typescript-eslint/consistent-type-assertions': ['error', {
+      'assertionStyle': 'angle-bracket',
+      'objectLiteralTypeAssertions': 'allow-as-parameter',
+    }],
     '@typescript-eslint/no-parameter-properties': ['error'],
     '@typescript-eslint/no-require-imports': ['error'],
     '@typescript-eslint/no-this-alias': ['error'],
-    '@typescript-eslint/no-triple-slash-reference': ['error'],
+    '@typescript-eslint/triple-slash-reference': ['error', {'path': 'never', 'types': 'never', 'lib': 'never'}],
     '@typescript-eslint/no-type-alias': 'off',
     '@typescript-eslint/no-unnecessary-qualifier': ['error'],
     '@typescript-eslint/no-unnecessary-type-assertion': ['error'],
@@ -101,12 +113,23 @@ module.exports  = {
     '@typescript-eslint/prefer-for-of': ['error'],
     '@typescript-eslint/prefer-function-type': ['error'],
     '@typescript-eslint/prefer-includes': ['error'],
-    '@typescript-eslint/prefer-interface': ['error'],
+    '@typescript-eslint/consistent-type-definitions': ['error'],
     '@typescript-eslint/prefer-namespace-keyword': 'off',
+    '@typescript-eslint/prefer-regexp-exec': 'error',
     '@typescript-eslint/prefer-string-starts-ends-with': ['error'],
     '@typescript-eslint/promise-function-async': 'off',
     '@typescript-eslint/restrict-plus-operands': ['error'],
+    '@typescript-eslint/strict-boolean-expressions': ['error'],
     '@typescript-eslint/type-annotation-spacing': ['error'],
+    '@typescript-eslint/typedef': ['error', {
+      'arrayDestructuring': false,
+      'arrowParameter': false,
+      'memberVariableDeclaration': false,
+      'objectDestructuring': false,
+      'parameter': false,
+      'propertyDeclaration': true,
+      'variableDeclaration': false,
+    }],
     '@typescript-eslint/unbound-method': ['error', {'ignoreStatic': true}],
     '@typescript-eslint/unified-signatures': ['error']
   },

--- a/eslint-config-5minds-typescript/package.json
+++ b/eslint-config-5minds-typescript/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Provide the eslint configs",
   "main": "index.js",
   "author": "5Minds IT-Solutions GmbH & Co. KG <info@5minds.de>",
@@ -20,12 +20,12 @@
   ],
   "dependencies": {
     "eslint-config-5minds": "^1.0.2",
-    "eslint": "^5.16.0",
-    "typescript": "~3.4.5"
+    "eslint": "^6.4.0",
+    "typescript": "~3.6.3"
   },
   "peerDependencies": {
     "eslint-plugin-6river": "^1.0.6",
-    "@typescript-eslint/eslint-plugin": "^1.7.0",
-    "@typescript-eslint/parser": "^1.7.0"
+    "@typescript-eslint/eslint-plugin": "^2.3.1",
+    "@typescript-eslint/parser": "^2.3.1"
   }
 }


### PR DESCRIPTION
Dieser PR:
- Updated dependencies zu ihrer neuesten Version
- Behebt Fehler in der konfiguration
   - Die options von `array-type` müssen anders angegeben werden
   - Ein paar Regeln wurden durch andere abgelöst
- Fügt ein paar neue Regeln hinzu, die eslint-typescript nun unterstützt
- Erweitert ein paar Regelkonfigurationen von Regeln, die jetzt ausführlicher eingestellt werden können